### PR TITLE
Added SVG import autofix

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,8 @@ module.exports = {
     'prevent-vanilla-html-elements': require('./rules/prevent-vanilla-html-elements'),
     // eslint-disable-next-line global-require
     'enforce-scss-modules': require('./rules/enforce-scss-modules'),
+    // eslint-disable-next-line global-require
+    'enforce-svg-import': require('./rules/enforce-svg-import'),
   },
   configs: {
     recommended: {
@@ -11,6 +13,7 @@ module.exports = {
       rules: {
         'reisbalans-rules/prevent-vanilla-html-elements': 'error',
         'reisbalans-rules/enforce-scss-modules': 'error',
+        'reisbalans-rules/enforce-svg-import': 'error',
       },
     },
   },

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "name": "eslint-plugin-reisbalans-rules",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "main": "index.js"
 }

--- a/rules/enforce-svg-import.js
+++ b/rules/enforce-svg-import.js
@@ -1,24 +1,19 @@
 const reportError = (context, node) => {
-  const parts = node.source.raw.split(".");
-  //  const name = parts[1].replace("/", "");
+  const parts = node.source.raw.split(".")
   const name = parts[1]
   .replace(/[A-Z\xC0-\xD6\xD8-\xDE]?[a-z\xDF-\xF6\xF8-\xFF]+|[A-Z\xC0-\xD6\xD8-\xDE]+(?![a-z\xDF-\xF6\xF8-\xFF])|\d+/g, (word) => word.charAt(0).toUpperCase() + word.slice(1))
-  .replace(/[\W+|_]/g, "");
-  console.log("name", name);
-  const fix = `import { ReactComponent as ${name} } from ${node.source.raw}`;
+  .replace(/[\W+|_]/g, "")
+  const fix = `import { ReactComponent as ${name} } from ${node.source.raw}`
   
   context.report({
     node,
     loc: node.loc,
     message: `Invalid svg import`,
-    suggest: {
-      message: `Please use "${fix}"`,
-      fix(fixer) {
-        return [fixer.replaceText(node, fix)];
-      }
+    fix(fixer) {
+      return [fixer.replaceText(node, fix)]
     }
-  });
-};
+  })
+}
 
 module.exports = {
   meta: {
@@ -33,14 +28,14 @@ module.exports = {
   create(context) {
     return {
       ImportDeclaration(node) {
-        if (node.source.type !== "Literal") return;
-        if (!node.source.raw.match(/\.svg/)) return;
+        if (node.source.type !== "Literal") return
+        if (!node.source.raw.match(/\.svg/)) return
         if (node.specifiers[0] && node.specifiers[0].imported && node.specifiers[0].imported.name === "ReactComponent") {
-          return;
+          return
         }
         
-        reportError(context, node);
+        reportError(context, node)
       }
-    };
+    }
   }
-};
+}

--- a/rules/enforce-svg-import.js
+++ b/rules/enforce-svg-import.js
@@ -1,0 +1,41 @@
+const reportError = (context, node) => {
+  const parts = node.source.raw.split(".");
+  const name = parts[1]
+  .replace(/[A-Z\xC0-\xD6\xD8-\xDE]?[a-z\xDF-\xF6\xF8-\xFF]+|[A-Z\xC0-\xD6\xD8-\xDE]+(?![a-z\xDF-\xF6\xF8-\xFF])|\d+/g, (word) => word.charAt(0).toUpperCase() + word.slice(1))
+  .replace(/[\W+|_]/g, "");
+  const fix = `import { ReactComponent as ${name} } from ${node.source.raw}`;
+  
+  context.report({
+    node,
+    loc: node.loc,
+    message: `Please use "${fix}"`,
+    fix(fixer) {
+      return [fixer.replaceTextRange([node.start, node.end], fix)];
+    }
+  });
+};
+
+module.exports = {
+  meta: {
+    docs: {
+      description: "Enforce the import of svg images",
+      recommended: true
+    },
+    fixable: "code",
+    type: "suggestion",
+    schema: []
+  },
+  create(context) {
+    return {
+      ImportDeclaration(node) {
+        if (node.source.type !== "Literal") return;
+        if (!node.source.raw.match(/\.svg/)) return;
+        if (node.specifiers[0] && node.specifiers[0].imported && node.specifiers[0].imported.name === "ReactComponent") {
+          return;
+        }
+        
+        reportError(context, node);
+      }
+    };
+  }
+};

--- a/rules/enforce-svg-import.js
+++ b/rules/enforce-svg-import.js
@@ -1,16 +1,21 @@
 const reportError = (context, node) => {
   const parts = node.source.raw.split(".");
+  //  const name = parts[1].replace("/", "");
   const name = parts[1]
   .replace(/[A-Z\xC0-\xD6\xD8-\xDE]?[a-z\xDF-\xF6\xF8-\xFF]+|[A-Z\xC0-\xD6\xD8-\xDE]+(?![a-z\xDF-\xF6\xF8-\xFF])|\d+/g, (word) => word.charAt(0).toUpperCase() + word.slice(1))
   .replace(/[\W+|_]/g, "");
+  console.log("name", name);
   const fix = `import { ReactComponent as ${name} } from ${node.source.raw}`;
   
   context.report({
     node,
     loc: node.loc,
-    message: `Please use "${fix}"`,
-    fix(fixer) {
-      return [fixer.replaceTextRange([node.start, node.end], fix)];
+    message: `Invalid svg import`,
+    suggest: {
+      message: `Please use "${fix}"`,
+      fix(fixer) {
+        return [fixer.replaceText(node, fix)];
+      }
     }
   });
 };

--- a/rules/enforce-svg-import.js
+++ b/rules/enforce-svg-import.js
@@ -1,7 +1,6 @@
 const reportError = (context, node) => {
-  const parts = node.source.raw.split(".")
-  const name = parts[1]
-  .replace(/[A-Z\xC0-\xD6\xD8-\xDE]?[a-z\xDF-\xF6\xF8-\xFF]+|[A-Z\xC0-\xD6\xD8-\xDE]+(?![a-z\xDF-\xF6\xF8-\xFF])|\d+/g, (word) => word.charAt(0).toUpperCase() + word.slice(1))
+  const name = node.source.raw.split('/').pop().split('.')[0]
+  .replace(/[A-Z]?[a-z]+|[A-Z]+(?![a-z])|\d+/g, (word) => word.charAt(0).toUpperCase() + word.slice(1))
   .replace(/[\W+|_]/g, "")
   const fix = `import { ReactComponent as ${name} } from ${node.source.raw}`
   


### PR DESCRIPTION
# What was the problem?

There are several ways that you could import an SVG but there is only one correct way to do this in React.
To make sure this one is being used, we now enforce that.

# What has been done?

Created an auto fix rule for SVG imports.

# How does it work?

It converts these imports:

```js
import MyIcon from './my_icon.svg'
import './myIcon.svg'
import * as MyIcon from './MyIcon.svg'
import { React as MyIcon } from './my-icon.svg'
```

Into:
```js
import { ReactComponent as MyIcon } from './my_icon.svg'
```

