### PR TITLE
Disallow interpolation for translations

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = {
     // eslint-disable-next-line global-require
     'enforce-svg-import': require('./rules/enforce-svg-import'),
     // eslint-disable-next-line global-require
-    'disallow-interpolation-for-translations': require('./rules/disallow-interpolation-for-translations'),
+    'disallow-tagged-templates-for-translations': require('./rules/disallow-tagged-templates-for-translations'),
   },
   configs: {
     recommended: {

--- a/index.js
+++ b/index.js
@@ -6,6 +6,8 @@ module.exports = {
     'enforce-scss-modules': require('./rules/enforce-scss-modules'),
     // eslint-disable-next-line global-require
     'enforce-svg-import': require('./rules/enforce-svg-import'),
+    // eslint-disable-next-line global-require
+    'disallow-interpolation-for-translations': require('./rules/disallow-interpolation-for-translations'),
   },
   configs: {
     recommended: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-reisbalans-rules",
-  "version": "1.2.1",
+  "version": "1.3.1",
   "main": "index.js",
   "devDependencies": {
     "jest": "^26.1.0"

--- a/rules/disallow-interpolation-for-translations.js
+++ b/rules/disallow-interpolation-for-translations.js
@@ -1,0 +1,37 @@
+const reportError = (context, node) => {
+  const reportConfig = {
+    node,
+    loc: node.loc,
+    message: `You cannot use interpolation templates for translations!`,
+  }
+  
+  const value = (node.quasi && node.quasi.quasis && node.quasi.quasis.length && node.quasi.quasis[0].value.raw) || undefined
+  if (!value) return context.report(reportConfig)
+  
+  const fix = `t("${value}")`
+  reportConfig.fix = (fixer) => {
+    return [fixer.replaceText(node, fix)]
+  }
+  
+  context.report(reportConfig)
+}
+
+module.exports = {
+  meta: {
+    docs: {
+      description: "Disallow string interpolation for translation tags",
+      recommended: true
+    },
+    fixable: "code",
+    type: "suggestion",
+    schema: []
+  },
+  create(context) {
+    return {
+      TaggedTemplateExpression(node) {
+        if (node.tag.name !== "t") return
+        reportError(context, node)
+      }
+    }
+  }
+}

--- a/rules/disallow-tagged-templates-for-translations.js
+++ b/rules/disallow-tagged-templates-for-translations.js
@@ -2,7 +2,7 @@ const reportError = (context, node) => {
   const reportConfig = {
     node,
     loc: node.loc,
-    message: `You cannot use interpolation templates for translations!`,
+    message: "You cannot use tagged templates for translations. This will not be extracted by our automated tools.",
   }
   
   const value = (node.quasi && node.quasi.quasis && node.quasi.quasis.length && node.quasi.quasis[0].value.raw) || undefined
@@ -19,7 +19,7 @@ const reportError = (context, node) => {
 module.exports = {
   meta: {
     docs: {
-      description: "Disallow string interpolation for translation tags",
+      description: "Disallow tagged templates for translation tags",
       recommended: true
     },
     fixable: "code",


### PR DESCRIPTION
# What was the problem?

using t`Dashboard` would not be extracted by our i18n-extraction tools.

# What has been done?

Added a new rule that autofixes string interpolated t tags to t("Dashboard")