### PR TITLE
Add no-comments-at-jsx-return-start rule and recommend it

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,14 +8,23 @@ module.exports = {
     'enforce-svg-import': require('./rules/enforce-svg-import'),
     // eslint-disable-next-line global-require
     'disallow-tagged-templates-for-translations': require('./rules/disallow-tagged-templates-for-translations'),
+    // eslint-disable-next-line global-require
+    'no-comments-at-jsx-return-start': require('./rules/no-comments-at-jsx-return-start'),
   },
   configs: {
     recommended: {
       plugins: ['reisbalans-rules'],
+      overrides: [{
+        files: ['**/*.tsx', '**/*.jsx'],
+        excludedFiles: ['*.spec.*'],
+        rules: {
+          'reisbalans-rules/no-comments-at-jsx-return-start': 'error',
+        }
+      }],
       rules: {
         'reisbalans-rules/prevent-vanilla-html-elements': 'error',
         'reisbalans-rules/enforce-scss-modules': 'error',
-        'reisbalans-rules/enforce-svg-import': 'error',
+        'reisbalans-rules/enforce-svg-import': 'error'
       },
     },
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-reisbalans-rules",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "main": "index.js",
   "devDependencies": {
     "jest": "^26.1.0"

--- a/rules/no-comments-at-jsx-return-start.js
+++ b/rules/no-comments-at-jsx-return-start.js
@@ -1,0 +1,38 @@
+// Stolen from https://github.com/facebook/create-react-app/issues/8687#issuecomment-747540857.
+
+module.exports = {
+  meta: {
+    docs: {
+      description: "Forbid inline comments at the start of the return of a JSX file due to a bug in Babel (https://github.com/facebook/create-react-app/issues/8687)",
+      recommended: true
+    },
+    fixable: "code",
+    type: "suggestion",
+    schema: []
+  },
+  create(context) {
+    return {
+      ReturnStatement: function (node) {
+        const comments = context.getCommentsInside(node)
+        const lineOfReturnStatement = node.loc.start.line
+
+        comments.forEach(comment => {
+          const lineOfComment = comment.loc.start.line
+
+          // Only check for inline comments
+          if (comment.type !== 'Line') return
+
+          // Only check for comments as FIRST THING after a `return` statement
+          if (lineOfReturnStatement !== lineOfComment && lineOfReturnStatement !== lineOfComment - 1) return
+
+          // We have an error, report it!
+          context.report({
+            node,
+            loc: node.loc,
+            message: 'Do not insert inline comments in return statement first two lines'
+          })
+        })
+      }
+    }
+  }
+}


### PR DESCRIPTION
![](https://media.giphy.com/media/vinApXdZo4P72/giphy.gif)

## Context
Due to a bug in Create React App, it could happen that the React app rendered with errors, causing the screen to be blank. See this issue: https://github.com/facebook/create-react-app/issues/8687.

While [this PR](https://github.com/reisbalans/reisbalans-interface/pull/529) resolves this issue in our repository, let's enforce ourselves by linting that we don't run into this again.

## What has been done?
* Added `no-comments-at-jsx-return-start`
* Recommend the rule

## How to test?
* Check out this repo locally
* In `reisbalans-interface@master`, change `package.json` to `../eslint-plugin-reisbalans-rules`
* Run `rm -rf node_modules && yarn`
* Run `yarn lint`
* See a lot of errors